### PR TITLE
Added standard (un)marshalBinary methods

### DIFF
--- a/address.go
+++ b/address.go
@@ -355,6 +355,19 @@ func hash(ingest []byte, cfg *blake2b.Config) []byte {
 	return hasher.Sum(nil)
 }
 
+func (a Address) MarshalBinary() ([]byte, error) {
+	return a.Bytes(), nil
+}
+
+func (a *Address) UnmarshalBinary(b []byte) error {
+	newAddr, err := NewFromBytes(b)
+	if err != nil {
+		return err
+	}
+	*a = newAddr
+	return nil
+}
+
 func (a Address) MarshalCBOR(w io.Writer) error {
 	if a == Undef {
 		return fmt.Errorf("cannot marshal undefined address")


### PR DESCRIPTION
tl;dr: without these hooks go-filecoin can't serialize any object that contains an embedded address so this PR is needed for gfc interop.  

Long version: While gfc makes an effort to play nice with cbg encodings it can only fallback to cbg encode/decode on the top level type being enc/decoded.  We would need to use cbg on all datastructures, or write our own complete cbor library that is aware of the cbg marshaling interface signatures in order for embedded datatypes implementing the cbg interfaces to be handled automatically without making this change. Another [alternative I proposed here](https://github.com/whyrusleeping/cbor-gen/issues/9) would be to make the cbg interface standardized so that external code could handle cbg interfaces automatically.

The functions introduced satisfy a relevant [standard go interface](https://golang.org/pkg/encoding/#BinaryMarshaler) so adding this code is good practice independent of the gfc motivation.