### PR TITLE
limit ID addresses to be at most 2^63-1

### DIFF
--- a/address.go
+++ b/address.go
@@ -149,6 +149,9 @@ func (a *Address) Scan(value interface{}) error {
 
 // NewIDAddress returns an address using the ID protocol.
 func NewIDAddress(id uint64) (Address, error) {
+	if id >= 1<<63 {
+		return Undef, xerrors.New("IDs must be less than 2^63")
+	}
 	return newAddress(ID, varint.ToUvarint(id))
 }
 

--- a/address.go
+++ b/address.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"strconv"
 
 	cbor "github.com/ipfs/go-ipld-cbor"
@@ -149,7 +150,7 @@ func (a *Address) Scan(value interface{}) error {
 
 // NewIDAddress returns an address using the ID protocol.
 func NewIDAddress(id uint64) (Address, error) {
-	if id >= 1<<63 {
+	if id > math.MaxInt64 {
 		return Undef, xerrors.New("IDs must be less than 2^63")
 	}
 	return newAddress(ID, varint.ToUvarint(id))

--- a/address_test.go
+++ b/address_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/base32"
 	"fmt"
-	"math"
 	"math/rand"
 	"strconv"
 	"testing"
@@ -76,7 +75,7 @@ func TestVectorsIDAddress(t *testing.T) {
 		{uint64(1024), "t01024"},
 		{uint64(1729), "t01729"},
 		{uint64(999999), "t0999999"},
-		{math.MaxUint64, fmt.Sprintf("t0%s", strconv.FormatUint(math.MaxUint64, 10))},
+		{(1 << 63) - 1, fmt.Sprintf("t0%s", strconv.FormatUint((1<<63)-1, 10))},
 	}
 
 	for _, tc := range testCases {

--- a/address_test.go
+++ b/address_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base32"
 	"fmt"
+	"math"
 	"math/rand"
 	"strconv"
 	"testing"
@@ -75,7 +76,7 @@ func TestVectorsIDAddress(t *testing.T) {
 		{uint64(1024), "t01024"},
 		{uint64(1729), "t01729"},
 		{uint64(999999), "t0999999"},
-		{(1 << 63) - 1, fmt.Sprintf("t0%s", strconv.FormatUint((1<<63)-1, 10))},
+		{math.MaxInt64, fmt.Sprintf("t0%s", strconv.FormatUint(math.MaxInt64, 10))},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
the new spec-conformant varint parser now limits things to 2^63-1 as the maximum value. To avoid any other weirdness, we add this check here as well. 