### PR TITLE
Only marshal null

### DIFF
--- a/address.go
+++ b/address.go
@@ -380,18 +380,6 @@ func (a *Address) MarshalCBOR(w io.Writer) error {
 func (a *Address) UnmarshalCBOR(r io.Reader) error {
 	br := cbg.GetPeeker(r)
 
-	pb, err := br.ReadByte()
-	if err != nil {
-		return err
-	}
-	if pb == cbg.CborNull[0] {
-		return nil
-	}
-	err = br.UnreadByte()
-	if err != nil {
-		return err
-	}
-
 	maj, extra, err := cbg.CborReadHeader(br)
 	if err != nil {
 		return err

--- a/address_test.go
+++ b/address_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/filecoin-project/go-crypto"
+	cbg "github.com/whyrusleeping/cbor-gen"
 )
 
 func init() {
@@ -466,13 +467,8 @@ func TestCborMarshalNilAddress(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var out *Address
-	if err := out.UnmarshalCBOR(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	if out != nil {
-		t.Fatalf("failed to roundtrip nil address")
+	if string(cbg.CborNull) != buf.String() {
+		t.Fatal("expected null")
 	}
 }
 


### PR DESCRIPTION
Handling null on unmarshal is impossible to do correctly:

1. If we have a CBOR null, and a non-nil receiver, there's no way to set the receiver pointer to nil.
2. If we have a non-null CBOR object, and a nil pointer receiver, this function would simply panic.