### PR TITLE
fix: slice bounds out of range

### DIFF
--- a/address.go
+++ b/address.go
@@ -313,6 +313,11 @@ func decode(a string) (Address, error) {
 	if err != nil {
 		return Undef, err
 	}
+
+	if len(payloadcksm)-ChecksumHashLength < 0 {
+		return Undef, ErrInvalidChecksum
+	}
+
 	payload := payloadcksm[:len(payloadcksm)-ChecksumHashLength]
 	cksm := payloadcksm[len(payloadcksm)-ChecksumHashLength:]
 

--- a/address_test.go
+++ b/address_test.go
@@ -360,6 +360,7 @@ func TestInvalidStringAddresses(t *testing.T) {
 		{"t2gfvuyh7v2sx3patm1k23wdzmhyhtmqctasbr24y", base32.CorruptInputError(16)}, // '1' is not in base32 alphabet
 		{"t2gfvuyh7v2sx3paTm1k23wdzmhyhtmqctasbr24y", base32.CorruptInputError(14)}, // 'T' is not in base32 alphabet
 		{"t2", ErrInvalidLength},
+		{"t1234", ErrInvalidChecksum},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
When the input is wrong (t1234) returns an error instead of panic