### PR TITLE
Support Address encoding based on network

### DIFF
--- a/address.go
+++ b/address.go
@@ -33,7 +33,10 @@ var addressAtlasEntry = atlas.BuildEntry(Address{}).Transform().
 	Complete()
 
 // Address is the go type that represents an address in the filecoin network.
-type Address struct{ str string }
+type Address struct{
+	str string
+	network Network
+}
 
 // Undef is the type that represents an undefined address.
 var Undef = Address{}
@@ -93,21 +96,11 @@ func (a Address) Bytes() []byte {
 
 // String returns an address encoded as a string.
 func (a Address) String() string {
-	str, err := encode(Testnet, a)
+	str, err := encode(a.network, a)
 	if err != nil {
 		panic(err) // I don't know if this one is okay
 	}
 	return str
-}
-
-// StringFor returns an address encoded as a string for a specific network.
-func (a Address) StringFor(network Network) (string, error) {
-	str, err := encode(network, a)
-	if err != nil {
-		return "", err
-	}
-
-	return str, nil
 }
 
 // Empty returns true if the address is empty, false otherwise.
@@ -159,6 +152,16 @@ func (a *Address) Scan(value interface{}) error {
 	default:
 		return xerrors.New("non-string types unsupported")
 	}
+}
+
+// SetNetwork sets network for an address
+func (a *Address) SetNetwork(network Network) {
+	a.network = network
+}
+
+// GetNetwork returns the network for an address
+func (a *Address) GetNetwork() Network {
+	return a.network
 }
 
 // NewIDAddress returns an address using the ID protocol.
@@ -243,7 +246,11 @@ func newAddress(protocol Protocol, payload []byte) (Address, error) {
 	buf[0] = protocol
 	copy(buf[1:], payload)
 
-	return Address{string(buf)}, nil
+	// return testnet address by default
+	return Address{
+		string(buf),
+		Testnet,
+	}, nil
 }
 
 func encode(network Network, addr Address) (string, error) {

--- a/address.go
+++ b/address.go
@@ -32,8 +32,8 @@ var addressAtlasEntry = atlas.BuildEntry(Address{}).Transform().
 		})).
 	Complete()
 
-// currentNetwork specifies which network the address belongs to
-var currentNetwork = Testnet
+// CurrentNetwork specifies which network the address belongs to
+var CurrentNetwork = Testnet
 
 // Address is the go type that represents an address in the filecoin network.
 type Address struct{ str string }
@@ -96,7 +96,7 @@ func (a Address) Bytes() []byte {
 
 // String returns an address encoded as a string.
 func (a Address) String() string {
-	str, err := encode(currentNetwork, a)
+	str, err := encode(CurrentNetwork, a)
 	if err != nil {
 		panic(err) // I don't know if this one is okay
 	}

--- a/address.go
+++ b/address.go
@@ -32,11 +32,11 @@ var addressAtlasEntry = atlas.BuildEntry(Address{}).Transform().
 		})).
 	Complete()
 
+// currentNetwork specifies which network the address belongs to
+var currentNetwork = Testnet
+
 // Address is the go type that represents an address in the filecoin network.
-type Address struct{
-	str string
-	network Network
-}
+type Address struct{ str string }
 
 // Undef is the type that represents an undefined address.
 var Undef = Address{}
@@ -96,7 +96,7 @@ func (a Address) Bytes() []byte {
 
 // String returns an address encoded as a string.
 func (a Address) String() string {
-	str, err := encode(a.network, a)
+	str, err := encode(currentNetwork, a)
 	if err != nil {
 		panic(err) // I don't know if this one is okay
 	}
@@ -152,16 +152,6 @@ func (a *Address) Scan(value interface{}) error {
 	default:
 		return xerrors.New("non-string types unsupported")
 	}
-}
-
-// SetNetwork sets network for an address
-func (a *Address) SetNetwork(network Network) {
-	a.network = network
-}
-
-// GetNetwork returns the network for an address
-func (a *Address) GetNetwork() Network {
-	return a.network
 }
 
 // NewIDAddress returns an address using the ID protocol.
@@ -246,11 +236,7 @@ func newAddress(protocol Protocol, payload []byte) (Address, error) {
 	buf[0] = protocol
 	copy(buf[1:], payload)
 
-	// return testnet address by default
-	return Address{
-		string(buf),
-		Testnet,
-	}, nil
+	return Address{string(buf)}, nil
 }
 
 func encode(network Network, addr Address) (string, error) {

--- a/address.go
+++ b/address.go
@@ -100,6 +100,16 @@ func (a Address) String() string {
 	return str
 }
 
+// StringFor returns an address encoded as a string for a specific network.
+func (a Address) StringFor(network Network) (string, error) {
+	str, err := encode(network, a)
+	if err != nil {
+		return "", err
+	}
+
+	return str, nil
+}
+
 // Empty returns true if the address is empty, false otherwise.
 func (a Address) Empty() bool {
 	return a == Undef

--- a/address_test.go
+++ b/address_test.go
@@ -203,6 +203,7 @@ func TestVectorSecp256k1Address(t *testing.T) {
 
 			// Testnet
 			// Round trip encoding and decoding from string
+			currentNetwork = Testnet
 			addr, err := NewSecp256k1Address(tc.input)
 			assert.NoError(err)
 			assert.Equal(tc.expectedTestnetAddrStr, addr.String())
@@ -228,8 +229,7 @@ func TestVectorSecp256k1Address(t *testing.T) {
 
 			// Mainnet
 			// Round trip encoding and decoding from string
-			addr.SetNetwork(Mainnet)
-			assert.Equal(Mainnet, addr.GetNetwork())
+			currentNetwork = Mainnet
 			assert.Equal(tc.expectedMainnetAddrStr, addr.String())
 
 			maybeMainnetAddr, err := NewFromString(tc.expectedMainnetAddrStr)
@@ -249,8 +249,6 @@ func TestVectorSecp256k1Address(t *testing.T) {
 			var newMainnetAddr Address
 			err = newMainnetAddr.UnmarshalJSON(mb)
 			assert.NoError(err)
-			// TODO support decoding with network natively
-			newMainnetAddr.SetNetwork(Mainnet)
 			assert.Equal(addr, newMainnetAddr)
 
 		})
@@ -321,6 +319,7 @@ func TestVectorActorAddress(t *testing.T) {
 
 			// Testnet
 			// Round trip encoding and decoding from string
+			currentNetwork = Testnet
 			addr, err := NewActorAddress(tc.input)
 			assert.NoError(err)
 			assert.Equal(tc.expectedTestnetAddrStr, addr.String())
@@ -346,8 +345,7 @@ func TestVectorActorAddress(t *testing.T) {
 
 			// Mainnet
 			// Round trip encoding and decoding from string
-			addr.SetNetwork(Mainnet)
-			assert.Equal(Mainnet, addr.GetNetwork())
+			currentNetwork = Mainnet
 			assert.Equal(tc.expectedMainnetAddrStr, addr.String())
 
 			maybeMainnetAddr, err := NewFromString(tc.expectedMainnetAddrStr)
@@ -367,8 +365,6 @@ func TestVectorActorAddress(t *testing.T) {
 			var newMainnetAddr Address
 			err = newMainnetAddr.UnmarshalJSON(mb)
 			assert.NoError(err)
-			// TODO support decoding with network natively
-			newMainnetAddr.SetNetwork(Mainnet)
 			assert.Equal(addr, newMainnetAddr)
 		})
 	}
@@ -429,6 +425,7 @@ func TestVectorBLSAddress(t *testing.T) {
 
 			// Testnet
 			// Round trip encoding and decoding from string
+			currentNetwork = Testnet
 			addr, err := NewBLSAddress(tc.input)
 			assert.NoError(err)
 			assert.Equal(tc.expectedTestnetAddrStr, addr.String())
@@ -454,8 +451,7 @@ func TestVectorBLSAddress(t *testing.T) {
 
 			// Mainnet
 			// Round trip encoding and decoding from string
-			addr.SetNetwork(Mainnet)
-			assert.Equal(Mainnet, addr.GetNetwork())
+			currentNetwork = Mainnet
 			assert.Equal(tc.expectedMainnetAddrStr, addr.String())
 
 			maybeMainnetAddr, err := NewFromString(tc.expectedMainnetAddrStr)
@@ -475,8 +471,6 @@ func TestVectorBLSAddress(t *testing.T) {
 			var newMainnetAddr Address
 			err = newMainnetAddr.UnmarshalJSON(mb)
 			assert.NoError(err)
-			// TODO support decoding with network natively
-			newMainnetAddr.SetNetwork(Mainnet)
 			assert.Equal(addr, newMainnetAddr)
 		})
 	}

--- a/address_test.go
+++ b/address_test.go
@@ -136,59 +136,78 @@ func TestSecp256k1Address(t *testing.T) {
 
 func TestVectorSecp256k1Address(t *testing.T) {
 	testCases := []struct {
-		input    []byte
-		expected string
+		input                  []byte
+		expectedTestnetAddrStr string
+		expectedMainnetAddrStr string
 	}{
 		{[]byte{4, 148, 2, 250, 195, 126, 100, 50, 164, 22, 163, 160, 202, 84,
 			38, 181, 24, 90, 179, 178, 79, 97, 52, 239, 162, 92, 228, 135, 200,
 			45, 46, 78, 19, 191, 69, 37, 17, 224, 210, 36, 84, 33, 248, 97, 59,
 			193, 13, 114, 250, 33, 102, 102, 169, 108, 59, 193, 57, 32, 211,
 			255, 35, 63, 208, 188, 5},
-			"t15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7pdrq"},
+			"t15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7pdrq",
+			"f15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7pdrq",
+		},
 
 		{[]byte{4, 118, 135, 185, 16, 55, 155, 242, 140, 190, 58, 234, 103, 75,
 			18, 0, 12, 107, 125, 186, 70, 255, 192, 95, 108, 148, 254, 42, 34,
 			187, 204, 38, 2, 255, 127, 92, 118, 242, 28, 165, 93, 54, 149, 145,
 			82, 176, 225, 232, 135, 145, 124, 57, 53, 118, 238, 240, 147, 246,
 			30, 189, 58, 208, 111, 127, 218},
-			"t12fiakbhe2gwd5cnmrenekasyn6v5tnaxaqizq6a"},
+			"t12fiakbhe2gwd5cnmrenekasyn6v5tnaxaqizq6a",
+			"f12fiakbhe2gwd5cnmrenekasyn6v5tnaxaqizq6a",
+		},
 		{[]byte{4, 222, 253, 208, 16, 1, 239, 184, 110, 1, 222, 213, 206, 52,
 			248, 71, 167, 58, 20, 129, 158, 230, 65, 188, 182, 11, 185, 41, 147,
 			89, 111, 5, 220, 45, 96, 95, 41, 133, 248, 209, 37, 129, 45, 172,
 			65, 99, 163, 150, 52, 155, 35, 193, 28, 194, 255, 53, 157, 229, 75,
 			226, 135, 234, 98, 49, 155},
-			"t1wbxhu3ypkuo6eyp6hjx6davuelxaxrvwb2kuwva"},
+			"t1wbxhu3ypkuo6eyp6hjx6davuelxaxrvwb2kuwva",
+			"f1wbxhu3ypkuo6eyp6hjx6davuelxaxrvwb2kuwva",
+		},
 		{[]byte{4, 3, 237, 18, 200, 20, 182, 177, 13, 46, 224, 157, 149, 180,
 			104, 141, 178, 209, 128, 208, 169, 163, 122, 107, 106, 125, 182, 61,
 			41, 129, 30, 233, 115, 4, 121, 216, 239, 145, 57, 233, 18, 73, 202,
 			189, 57, 50, 145, 207, 229, 210, 119, 186, 118, 222, 69, 227, 224,
 			133, 163, 118, 129, 191, 54, 69, 210},
-			"t1xtwapqc6nh4si2hcwpr3656iotzmlwumogqbuaa"},
+			"t1xtwapqc6nh4si2hcwpr3656iotzmlwumogqbuaa",
+			"f1xtwapqc6nh4si2hcwpr3656iotzmlwumogqbuaa",
+		},
 		{[]byte{4, 247, 150, 129, 154, 142, 39, 22, 49, 175, 124, 24, 151, 151,
 			181, 69, 214, 2, 37, 147, 97, 71, 230, 1, 14, 101, 98, 179, 206, 158,
 			254, 139, 16, 20, 65, 97, 169, 30, 208, 180, 236, 137, 8, 0, 37, 63,
 			166, 252, 32, 172, 144, 251, 241, 251, 242, 113, 48, 164, 236, 195,
 			228, 3, 183, 5, 118},
-			"t1xcbgdhkgkwht3hrrnui3jdopeejsoatkzmoltqy"},
+			"t1xcbgdhkgkwht3hrrnui3jdopeejsoatkzmoltqy",
+			"f1xcbgdhkgkwht3hrrnui3jdopeejsoatkzmoltqy",
+		},
 		{[]byte{4, 66, 131, 43, 248, 124, 206, 158, 163, 69, 185, 3, 80, 222,
 			125, 52, 149, 133, 156, 164, 73, 5, 156, 94, 136, 221, 231, 66, 133,
 			223, 251, 158, 192, 30, 186, 188, 95, 200, 98, 104, 207, 234, 235,
 			167, 174, 5, 191, 184, 214, 142, 183, 90, 82, 104, 120, 44, 248, 111,
 			200, 112, 43, 239, 138, 31, 224},
-			"t17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy"},
+			"t17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy",
+			"f17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy",
+		},
 	}
 
 	for _, tc := range testCases {
 		tc := tc
-		t.Run(fmt.Sprintf("testing secp256k1 address: %s", tc.expected), func(t *testing.T) {
+		name := fmt.Sprintf(
+			"testing secp256k1 address: %s (testnet), %s (mainnet)",
+			tc.expectedTestnetAddrStr,
+			tc.expectedMainnetAddrStr,
+		)
+		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
+			// Address#String
 			// Round trip encoding and decoding from string
 			addr, err := NewSecp256k1Address(tc.input)
 			assert.NoError(err)
-			assert.Equal(tc.expected, addr.String())
+			assert.Equal(tc.expectedTestnetAddrStr, addr.String())
 
-			maybeAddr, err := NewFromString(tc.expected)
+			maybeAddr, err := NewFromString(tc.expectedTestnetAddrStr)
 			assert.NoError(err)
 			assert.Equal(SECP256K1, maybeAddr.Protocol())
 			assert.Equal(addressHash(tc.input), maybeAddr.Payload())
@@ -206,6 +225,37 @@ func TestVectorSecp256k1Address(t *testing.T) {
 			err = newAddr.UnmarshalJSON(b)
 			assert.NoError(err)
 			assert.Equal(addr, newAddr)
+
+			// Address#StringFor
+			// Round trip encoding and decoding from string for testnet
+			testnetAddrStr, err := addr.StringFor(Testnet)
+			assert.NoError(err)
+			assert.Equal(tc.expectedTestnetAddrStr, testnetAddrStr)
+
+			maybeTestnetAddr, err := NewFromString(tc.expectedTestnetAddrStr)
+			assert.NoError(err)
+			assert.Equal(SECP256K1, maybeTestnetAddr.Protocol())
+			assert.Equal(addressHash(tc.input), maybeTestnetAddr.Payload())
+
+			// Round trip to and from bytes for testnet
+			maybeTestnetAddrBytes, err := NewFromBytes(maybeTestnetAddr.Bytes())
+			assert.NoError(err)
+			assert.Equal(maybeTestnetAddr, maybeTestnetAddrBytes)
+
+			// Round trip encoding and decoding from string for mainnet
+			mainnetAddrStr, err := addr.StringFor(Mainnet)
+			assert.NoError(err)
+			assert.Equal(tc.expectedMainnetAddrStr, mainnetAddrStr)
+
+			maybeMainnetAddr, err := NewFromString(tc.expectedMainnetAddrStr)
+			assert.NoError(err)
+			assert.Equal(SECP256K1, maybeMainnetAddr.Protocol())
+			assert.Equal(addressHash(tc.input), maybeMainnetAddr.Payload())
+
+			// Round trip to and from bytes for mainnet
+			maybeMainnetAddrBytes, err := NewFromBytes(maybeMainnetAddr.Bytes())
+			assert.NoError(err)
+			assert.Equal(maybeMainnetAddr, maybeMainnetAddrBytes)
 		})
 	}
 }
@@ -232,36 +282,53 @@ func TestRandomActorAddress(t *testing.T) {
 func TestVectorActorAddress(t *testing.T) {
 	testCases := []struct {
 		input    []byte
-		expected string
+		expectedTestnetAddrStr string
+		expectedMainnetAddrStr string
 	}{
 		{[]byte{118, 18, 129, 144, 205, 240, 104, 209, 65, 128, 68, 172, 192,
 			62, 11, 103, 129, 151, 13, 96},
-			"t24vg6ut43yw2h2jqydgbg2xq7x6f4kub3bg6as6i"},
+			"t24vg6ut43yw2h2jqydgbg2xq7x6f4kub3bg6as6i",
+			"f24vg6ut43yw2h2jqydgbg2xq7x6f4kub3bg6as6i",
+		},
 		{[]byte{44, 175, 184, 226, 224, 107, 186, 152, 234, 101, 124, 92, 245,
 			244, 32, 35, 170, 35, 232, 142},
-			"t25nml2cfbljvn4goqtclhifepvfnicv6g7mfmmvq"},
+			"t25nml2cfbljvn4goqtclhifepvfnicv6g7mfmmvq",
+			"f25nml2cfbljvn4goqtclhifepvfnicv6g7mfmmvq",
+		},
 		{[]byte{2, 44, 158, 14, 162, 157, 143, 64, 197, 106, 190, 195, 92, 141,
 			88, 125, 160, 166, 76, 24},
-			"t2nuqrg7vuysaue2pistjjnt3fadsdzvyuatqtfei"},
+			"t2nuqrg7vuysaue2pistjjnt3fadsdzvyuatqtfei",
+			"f2nuqrg7vuysaue2pistjjnt3fadsdzvyuatqtfei",
+		},
 		{[]byte{223, 236, 3, 14, 32, 79, 15, 89, 216, 15, 29, 94, 233, 29, 253,
 			6, 109, 127, 99, 189},
-			"t24dd4ox4c2vpf5vk5wkadgyyn6qtuvgcpxxon64a"},
+			"t24dd4ox4c2vpf5vk5wkadgyyn6qtuvgcpxxon64a",
+			"f24dd4ox4c2vpf5vk5wkadgyyn6qtuvgcpxxon64a",
+		},
 		{[]byte{61, 58, 137, 232, 221, 171, 84, 120, 50, 113, 108, 109, 70, 140,
 			53, 96, 201, 244, 127, 216},
-			"t2gfvuyh7v2sx3patm5k23wdzmhyhtmqctasbr23y"},
+			"t2gfvuyh7v2sx3patm5k23wdzmhyhtmqctasbr23y",
+			"f2gfvuyh7v2sx3patm5k23wdzmhyhtmqctasbr23y",
+		},
 	}
 
 	for _, tc := range testCases {
 		tc := tc
-		t.Run(fmt.Sprintf("testing Actor address: %s", tc.expected), func(t *testing.T) {
+		name := fmt.Sprintf(
+			"testing Actor address: %s (testnet), %s (mainnet)",
+			tc.expectedTestnetAddrStr,
+			tc.expectedMainnetAddrStr,
+		)
+		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
+			// Address#String
 			// Round trip encoding and decoding from string
 			addr, err := NewActorAddress(tc.input)
 			assert.NoError(err)
-			assert.Equal(tc.expected, addr.String())
+			assert.Equal(tc.expectedTestnetAddrStr, addr.String())
 
-			maybeAddr, err := NewFromString(tc.expected)
+			maybeAddr, err := NewFromString(tc.expectedTestnetAddrStr)
 			assert.NoError(err)
 			assert.Equal(Actor, maybeAddr.Protocol())
 			assert.Equal(addressHash(tc.input), maybeAddr.Payload())
@@ -279,6 +346,37 @@ func TestVectorActorAddress(t *testing.T) {
 			err = newAddr.UnmarshalJSON(b)
 			assert.NoError(err)
 			assert.Equal(addr, newAddr)
+
+			// Address#StringFor
+			// Round trip encoding and decoding from string for testnet
+			testnetAddrStr, err := addr.StringFor(Testnet)
+			assert.NoError(err)
+			assert.Equal(tc.expectedTestnetAddrStr, testnetAddrStr)
+
+			maybeTestnetAddr, err := NewFromString(tc.expectedTestnetAddrStr)
+			assert.NoError(err)
+			assert.Equal(Actor, maybeTestnetAddr.Protocol())
+			assert.Equal(addressHash(tc.input), maybeTestnetAddr.Payload())
+
+			// Round trip to and from bytes for testnet
+			maybeTestnetAddrBytes, err := NewFromBytes(maybeTestnetAddr.Bytes())
+			assert.NoError(err)
+			assert.Equal(maybeTestnetAddr, maybeTestnetAddrBytes)
+
+			// Round trip encoding and decoding from string for mainnet
+			mainnetAddrStr, err := addr.StringFor(Mainnet)
+			assert.NoError(err)
+			assert.Equal(tc.expectedMainnetAddrStr, mainnetAddrStr)
+
+			maybeMainnetAddr, err := NewFromString(tc.expectedMainnetAddrStr)
+			assert.NoError(err)
+			assert.Equal(Actor, maybeMainnetAddr.Protocol())
+			assert.Equal(addressHash(tc.input), maybeMainnetAddr.Payload())
+
+			// Round trip to and from bytes for testnet
+			maybeMainnetAddrBytes, err := NewFromBytes(maybeMainnetAddr.Bytes())
+			assert.NoError(err)
+			assert.Equal(maybeMainnetAddr, maybeMainnetAddrBytes)
 		})
 	}
 }
@@ -286,46 +384,63 @@ func TestVectorActorAddress(t *testing.T) {
 func TestVectorBLSAddress(t *testing.T) {
 	testCases := []struct {
 		input    []byte
-		expected string
+		expectedTestnetAddrStr string
+		expectedMainnetAddrStr string
 	}{
 		{[]byte{173, 88, 223, 105, 110, 45, 78, 145, 234, 134, 200, 129, 233, 56,
 			186, 78, 168, 27, 57, 94, 18, 121, 123, 132, 185, 207, 49, 75, 149, 70,
 			112, 94, 131, 156, 122, 153, 214, 6, 178, 71, 221, 180, 249, 172, 122,
 			52, 20, 221},
-			"t3vvmn62lofvhjd2ugzca6sof2j2ubwok6cj4xxbfzz4yuxfkgobpihhd2thlanmsh3w2ptld2gqkn2jvlss4a"},
+			"t3vvmn62lofvhjd2ugzca6sof2j2ubwok6cj4xxbfzz4yuxfkgobpihhd2thlanmsh3w2ptld2gqkn2jvlss4a",
+			"f3vvmn62lofvhjd2ugzca6sof2j2ubwok6cj4xxbfzz4yuxfkgobpihhd2thlanmsh3w2ptld2gqkn2jvlss4a",
+		},
 		{[]byte{179, 41, 79, 10, 46, 41, 224, 198, 110, 188, 35, 93, 47, 237,
 			202, 86, 151, 191, 120, 74, 246, 5, 199, 90, 246, 8, 230, 166, 61, 92,
 			211, 142, 168, 92, 168, 152, 158, 14, 253, 233, 24, 139, 56, 47,
 			147, 114, 70, 13},
-			"t3wmuu6crofhqmm3v4enos73okk2l366ck6yc4owxwbdtkmpk42ohkqxfitcpa57pjdcftql4tojda2poeruwa"},
+			"t3wmuu6crofhqmm3v4enos73okk2l366ck6yc4owxwbdtkmpk42ohkqxfitcpa57pjdcftql4tojda2poeruwa",
+			"f3wmuu6crofhqmm3v4enos73okk2l366ck6yc4owxwbdtkmpk42ohkqxfitcpa57pjdcftql4tojda2poeruwa",
+		},
 		{[]byte{150, 161, 163, 228, 234, 122, 20, 212, 153, 133, 230, 97, 178,
 			36, 1, 212, 79, 237, 64, 45, 29, 9, 37, 178, 67, 201, 35, 88, 156,
 			15, 188, 126, 50, 205, 4, 226, 158, 215, 141, 21, 211, 125, 58, 170,
 			63, 230, 218, 51},
-			"t3s2q2hzhkpiknjgmf4zq3ejab2rh62qbndueslmsdzervrhapxr7dftie4kpnpdiv2n6tvkr743ndhrsw6d3a"},
+			"t3s2q2hzhkpiknjgmf4zq3ejab2rh62qbndueslmsdzervrhapxr7dftie4kpnpdiv2n6tvkr743ndhrsw6d3a",
+			"f3s2q2hzhkpiknjgmf4zq3ejab2rh62qbndueslmsdzervrhapxr7dftie4kpnpdiv2n6tvkr743ndhrsw6d3a",
+		},
 		{[]byte{134, 180, 84, 37, 140, 88, 148, 117, 247, 209, 111, 90, 172, 1,
 			138, 121, 246, 193, 22, 157, 32, 252, 51, 146, 29, 216, 181, 206, 28,
 			172, 108, 52, 143, 144, 163, 96, 54, 36, 246, 174, 185, 27, 100, 81,
 			140, 46, 128, 149},
-			"t3q22fijmmlckhl56rn5nkyamkph3mcfu5ed6dheq53c244hfmnq2i7efdma3cj5voxenwiummf2ajlsbxc65a"},
+			"t3q22fijmmlckhl56rn5nkyamkph3mcfu5ed6dheq53c244hfmnq2i7efdma3cj5voxenwiummf2ajlsbxc65a",
+			"f3q22fijmmlckhl56rn5nkyamkph3mcfu5ed6dheq53c244hfmnq2i7efdma3cj5voxenwiummf2ajlsbxc65a",
+		},
 		{[]byte{167, 114, 107, 3, 128, 34, 247, 90, 56, 70, 23, 88, 83, 96, 206,
 			230, 41, 7, 10, 45, 157, 40, 113, 41, 101, 229, 242, 110, 204, 64,
 			133, 131, 130, 128, 55, 36, 237, 52, 242, 114, 3, 54, 240, 157, 182,
 			49, 240, 116},
-			"t3u5zgwa4ael3vuocgc5mfgygo4yuqocrntuuhcklf4xzg5tcaqwbyfabxetwtj4tsam3pbhnwghyhijr5mixa"},
+			"t3u5zgwa4ael3vuocgc5mfgygo4yuqocrntuuhcklf4xzg5tcaqwbyfabxetwtj4tsam3pbhnwghyhijr5mixa",
+			"f3u5zgwa4ael3vuocgc5mfgygo4yuqocrntuuhcklf4xzg5tcaqwbyfabxetwtj4tsam3pbhnwghyhijr5mixa",
+		},
 	}
 
 	for _, tc := range testCases {
 		tc := tc
-		t.Run(fmt.Sprintf("testing bls address: %s", tc.expected), func(t *testing.T) {
+		name := fmt.Sprintf(
+			"testing bls address: %s (testnet), %s (mainnet)",
+			tc.expectedTestnetAddrStr,
+			tc.expectedMainnetAddrStr,
+		)
+		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
+			// Address#String
 			// Round trip encoding and decoding from string
 			addr, err := NewBLSAddress(tc.input)
 			assert.NoError(err)
-			assert.Equal(tc.expected, addr.String())
+			assert.Equal(tc.expectedTestnetAddrStr, addr.String())
 
-			maybeAddr, err := NewFromString(tc.expected)
+			maybeAddr, err := NewFromString(tc.expectedTestnetAddrStr)
 			assert.NoError(err)
 			assert.Equal(BLS, maybeAddr.Protocol())
 			assert.Equal(tc.input, maybeAddr.Payload())
@@ -343,6 +458,37 @@ func TestVectorBLSAddress(t *testing.T) {
 			err = newAddr.UnmarshalJSON(b)
 			assert.NoError(err)
 			assert.Equal(addr, newAddr)
+
+			// Address#StringFor
+			// Round trip encoding and decoding from string for testnet
+			testnetAddrStr, err := addr.StringFor(Testnet)
+			assert.NoError(err)
+			assert.Equal(tc.expectedTestnetAddrStr, testnetAddrStr)
+
+			maybeTestnetAddr, err := NewFromString(tc.expectedTestnetAddrStr)
+			assert.NoError(err)
+			assert.Equal(BLS, maybeTestnetAddr.Protocol())
+			assert.Equal(tc.input, maybeTestnetAddr.Payload())
+
+			// Round trip to and from bytes for testnet
+			maybeTestnetAddrBytes, err := NewFromBytes(maybeTestnetAddr.Bytes())
+			assert.NoError(err)
+			assert.Equal(maybeTestnetAddr, maybeTestnetAddrBytes)
+
+			// Round trip encoding and decoding from string for mainnet
+			mainnetAddrStr, err := addr.StringFor(Mainnet)
+			assert.NoError(err)
+			assert.Equal(tc.expectedMainnetAddrStr, mainnetAddrStr)
+
+			maybeMainnetAddr, err := NewFromString(tc.expectedMainnetAddrStr)
+			assert.NoError(err)
+			assert.Equal(BLS, maybeMainnetAddr.Protocol())
+			assert.Equal(tc.input, maybeMainnetAddr.Payload())
+
+			// Round trip to and from bytes for mainnet
+			maybeMainnetAddrBytes, err := NewFromBytes(maybeMainnetAddr.Bytes())
+			assert.NoError(err)
+			assert.Equal(maybeMainnetAddr, maybeMainnetAddrBytes)
 		})
 	}
 }

--- a/address_test.go
+++ b/address_test.go
@@ -203,7 +203,7 @@ func TestVectorSecp256k1Address(t *testing.T) {
 
 			// Testnet
 			// Round trip encoding and decoding from string
-			currentNetwork = Testnet
+			CurrentNetwork = Testnet
 			addr, err := NewSecp256k1Address(tc.input)
 			assert.NoError(err)
 			assert.Equal(tc.expectedTestnetAddrStr, addr.String())
@@ -229,7 +229,7 @@ func TestVectorSecp256k1Address(t *testing.T) {
 
 			// Mainnet
 			// Round trip encoding and decoding from string
-			currentNetwork = Mainnet
+			CurrentNetwork = Mainnet
 			assert.Equal(tc.expectedMainnetAddrStr, addr.String())
 
 			maybeMainnetAddr, err := NewFromString(tc.expectedMainnetAddrStr)
@@ -319,7 +319,7 @@ func TestVectorActorAddress(t *testing.T) {
 
 			// Testnet
 			// Round trip encoding and decoding from string
-			currentNetwork = Testnet
+			CurrentNetwork = Testnet
 			addr, err := NewActorAddress(tc.input)
 			assert.NoError(err)
 			assert.Equal(tc.expectedTestnetAddrStr, addr.String())
@@ -345,7 +345,7 @@ func TestVectorActorAddress(t *testing.T) {
 
 			// Mainnet
 			// Round trip encoding and decoding from string
-			currentNetwork = Mainnet
+			CurrentNetwork = Mainnet
 			assert.Equal(tc.expectedMainnetAddrStr, addr.String())
 
 			maybeMainnetAddr, err := NewFromString(tc.expectedMainnetAddrStr)
@@ -425,7 +425,7 @@ func TestVectorBLSAddress(t *testing.T) {
 
 			// Testnet
 			// Round trip encoding and decoding from string
-			currentNetwork = Testnet
+			CurrentNetwork = Testnet
 			addr, err := NewBLSAddress(tc.input)
 			assert.NoError(err)
 			assert.Equal(tc.expectedTestnetAddrStr, addr.String())
@@ -451,7 +451,7 @@ func TestVectorBLSAddress(t *testing.T) {
 
 			// Mainnet
 			// Round trip encoding and decoding from string
-			currentNetwork = Mainnet
+			CurrentNetwork = Mainnet
 			assert.Equal(tc.expectedMainnetAddrStr, addr.String())
 
 			maybeMainnetAddr, err := NewFromString(tc.expectedMainnetAddrStr)

--- a/address_test.go
+++ b/address_test.go
@@ -201,61 +201,58 @@ func TestVectorSecp256k1Address(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			// Address#String
+			// Testnet
 			// Round trip encoding and decoding from string
 			addr, err := NewSecp256k1Address(tc.input)
 			assert.NoError(err)
 			assert.Equal(tc.expectedTestnetAddrStr, addr.String())
-
-			maybeAddr, err := NewFromString(tc.expectedTestnetAddrStr)
-			assert.NoError(err)
-			assert.Equal(SECP256K1, maybeAddr.Protocol())
-			assert.Equal(addressHash(tc.input), maybeAddr.Payload())
-
-			// Round trip to and from bytes
-			maybeAddrBytes, err := NewFromBytes(maybeAddr.Bytes())
-			assert.NoError(err)
-			assert.Equal(maybeAddr, maybeAddrBytes)
-
-			// Round trip encoding and decoding json
-			b, err := addr.MarshalJSON()
-			assert.NoError(err)
-
-			var newAddr Address
-			err = newAddr.UnmarshalJSON(b)
-			assert.NoError(err)
-			assert.Equal(addr, newAddr)
-
-			// Address#StringFor
-			// Round trip encoding and decoding from string for testnet
-			testnetAddrStr, err := addr.StringFor(Testnet)
-			assert.NoError(err)
-			assert.Equal(tc.expectedTestnetAddrStr, testnetAddrStr)
 
 			maybeTestnetAddr, err := NewFromString(tc.expectedTestnetAddrStr)
 			assert.NoError(err)
 			assert.Equal(SECP256K1, maybeTestnetAddr.Protocol())
 			assert.Equal(addressHash(tc.input), maybeTestnetAddr.Payload())
 
-			// Round trip to and from bytes for testnet
+			// Round trip to and from bytes
 			maybeTestnetAddrBytes, err := NewFromBytes(maybeTestnetAddr.Bytes())
 			assert.NoError(err)
 			assert.Equal(maybeTestnetAddr, maybeTestnetAddrBytes)
 
-			// Round trip encoding and decoding from string for mainnet
-			mainnetAddrStr, err := addr.StringFor(Mainnet)
+			// Round trip encoding and decoding json
+			tb, err := addr.MarshalJSON()
 			assert.NoError(err)
-			assert.Equal(tc.expectedMainnetAddrStr, mainnetAddrStr)
+
+			var newTestnetAddr Address
+			err = newTestnetAddr.UnmarshalJSON(tb)
+			assert.NoError(err)
+			assert.Equal(addr, newTestnetAddr)
+
+			// Mainnet
+			// Round trip encoding and decoding from string
+			addr.SetNetwork(Mainnet)
+			assert.Equal(Mainnet, addr.GetNetwork())
+			assert.Equal(tc.expectedMainnetAddrStr, addr.String())
 
 			maybeMainnetAddr, err := NewFromString(tc.expectedMainnetAddrStr)
 			assert.NoError(err)
 			assert.Equal(SECP256K1, maybeMainnetAddr.Protocol())
 			assert.Equal(addressHash(tc.input), maybeMainnetAddr.Payload())
 
-			// Round trip to and from bytes for mainnet
+			// Round trip to and from bytes
 			maybeMainnetAddrBytes, err := NewFromBytes(maybeMainnetAddr.Bytes())
 			assert.NoError(err)
 			assert.Equal(maybeMainnetAddr, maybeMainnetAddrBytes)
+
+			// Round trip encoding and decoding json
+			mb, err := addr.MarshalJSON()
+			assert.NoError(err)
+
+			var newMainnetAddr Address
+			err = newMainnetAddr.UnmarshalJSON(mb)
+			assert.NoError(err)
+			// TODO support decoding with network natively
+			newMainnetAddr.SetNetwork(Mainnet)
+			assert.Equal(addr, newMainnetAddr)
+
 		})
 	}
 }
@@ -322,61 +319,57 @@ func TestVectorActorAddress(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			// Address#String
+			// Testnet
 			// Round trip encoding and decoding from string
 			addr, err := NewActorAddress(tc.input)
 			assert.NoError(err)
 			assert.Equal(tc.expectedTestnetAddrStr, addr.String())
-
-			maybeAddr, err := NewFromString(tc.expectedTestnetAddrStr)
-			assert.NoError(err)
-			assert.Equal(Actor, maybeAddr.Protocol())
-			assert.Equal(addressHash(tc.input), maybeAddr.Payload())
-
-			// Round trip to and from bytes
-			maybeAddrBytes, err := NewFromBytes(maybeAddr.Bytes())
-			assert.NoError(err)
-			assert.Equal(maybeAddr, maybeAddrBytes)
-
-			// Round trip encoding and decoding json
-			b, err := addr.MarshalJSON()
-			assert.NoError(err)
-
-			var newAddr Address
-			err = newAddr.UnmarshalJSON(b)
-			assert.NoError(err)
-			assert.Equal(addr, newAddr)
-
-			// Address#StringFor
-			// Round trip encoding and decoding from string for testnet
-			testnetAddrStr, err := addr.StringFor(Testnet)
-			assert.NoError(err)
-			assert.Equal(tc.expectedTestnetAddrStr, testnetAddrStr)
 
 			maybeTestnetAddr, err := NewFromString(tc.expectedTestnetAddrStr)
 			assert.NoError(err)
 			assert.Equal(Actor, maybeTestnetAddr.Protocol())
 			assert.Equal(addressHash(tc.input), maybeTestnetAddr.Payload())
 
-			// Round trip to and from bytes for testnet
+			// Round trip to and from bytes
 			maybeTestnetAddrBytes, err := NewFromBytes(maybeTestnetAddr.Bytes())
 			assert.NoError(err)
 			assert.Equal(maybeTestnetAddr, maybeTestnetAddrBytes)
 
-			// Round trip encoding and decoding from string for mainnet
-			mainnetAddrStr, err := addr.StringFor(Mainnet)
+			// Round trip encoding and decoding json
+			tb, err := addr.MarshalJSON()
 			assert.NoError(err)
-			assert.Equal(tc.expectedMainnetAddrStr, mainnetAddrStr)
+
+			var newTestnetAddr Address
+			err = newTestnetAddr.UnmarshalJSON(tb)
+			assert.NoError(err)
+			assert.Equal(addr, newTestnetAddr)
+
+			// Mainnet
+			// Round trip encoding and decoding from string
+			addr.SetNetwork(Mainnet)
+			assert.Equal(Mainnet, addr.GetNetwork())
+			assert.Equal(tc.expectedMainnetAddrStr, addr.String())
 
 			maybeMainnetAddr, err := NewFromString(tc.expectedMainnetAddrStr)
 			assert.NoError(err)
 			assert.Equal(Actor, maybeMainnetAddr.Protocol())
 			assert.Equal(addressHash(tc.input), maybeMainnetAddr.Payload())
 
-			// Round trip to and from bytes for testnet
+			// Round trip to and from bytes
 			maybeMainnetAddrBytes, err := NewFromBytes(maybeMainnetAddr.Bytes())
 			assert.NoError(err)
 			assert.Equal(maybeMainnetAddr, maybeMainnetAddrBytes)
+
+			// Round trip encoding and decoding json
+			mb, err := addr.MarshalJSON()
+			assert.NoError(err)
+
+			var newMainnetAddr Address
+			err = newMainnetAddr.UnmarshalJSON(mb)
+			assert.NoError(err)
+			// TODO support decoding with network natively
+			newMainnetAddr.SetNetwork(Mainnet)
+			assert.Equal(addr, newMainnetAddr)
 		})
 	}
 }
@@ -434,61 +427,57 @@ func TestVectorBLSAddress(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			// Address#String
+			// Testnet
 			// Round trip encoding and decoding from string
 			addr, err := NewBLSAddress(tc.input)
 			assert.NoError(err)
 			assert.Equal(tc.expectedTestnetAddrStr, addr.String())
-
-			maybeAddr, err := NewFromString(tc.expectedTestnetAddrStr)
-			assert.NoError(err)
-			assert.Equal(BLS, maybeAddr.Protocol())
-			assert.Equal(tc.input, maybeAddr.Payload())
-
-			// Round trip to and from bytes
-			maybeAddrBytes, err := NewFromBytes(maybeAddr.Bytes())
-			assert.NoError(err)
-			assert.Equal(maybeAddr, maybeAddrBytes)
-
-			// Round trip encoding and decoding json
-			b, err := addr.MarshalJSON()
-			assert.NoError(err)
-
-			var newAddr Address
-			err = newAddr.UnmarshalJSON(b)
-			assert.NoError(err)
-			assert.Equal(addr, newAddr)
-
-			// Address#StringFor
-			// Round trip encoding and decoding from string for testnet
-			testnetAddrStr, err := addr.StringFor(Testnet)
-			assert.NoError(err)
-			assert.Equal(tc.expectedTestnetAddrStr, testnetAddrStr)
 
 			maybeTestnetAddr, err := NewFromString(tc.expectedTestnetAddrStr)
 			assert.NoError(err)
 			assert.Equal(BLS, maybeTestnetAddr.Protocol())
 			assert.Equal(tc.input, maybeTestnetAddr.Payload())
 
-			// Round trip to and from bytes for testnet
+			// Round trip to and from bytes
 			maybeTestnetAddrBytes, err := NewFromBytes(maybeTestnetAddr.Bytes())
 			assert.NoError(err)
 			assert.Equal(maybeTestnetAddr, maybeTestnetAddrBytes)
 
-			// Round trip encoding and decoding from string for mainnet
-			mainnetAddrStr, err := addr.StringFor(Mainnet)
+			// Round trip encoding and decoding json
+			tb, err := addr.MarshalJSON()
 			assert.NoError(err)
-			assert.Equal(tc.expectedMainnetAddrStr, mainnetAddrStr)
+
+			var newTestnetAddr Address
+			err = newTestnetAddr.UnmarshalJSON(tb)
+			assert.NoError(err)
+			assert.Equal(addr, newTestnetAddr)
+
+			// Mainnet
+			// Round trip encoding and decoding from string
+			addr.SetNetwork(Mainnet)
+			assert.Equal(Mainnet, addr.GetNetwork())
+			assert.Equal(tc.expectedMainnetAddrStr, addr.String())
 
 			maybeMainnetAddr, err := NewFromString(tc.expectedMainnetAddrStr)
 			assert.NoError(err)
 			assert.Equal(BLS, maybeMainnetAddr.Protocol())
 			assert.Equal(tc.input, maybeMainnetAddr.Payload())
 
-			// Round trip to and from bytes for mainnet
+			// Round trip to and from bytes
 			maybeMainnetAddrBytes, err := NewFromBytes(maybeMainnetAddr.Bytes())
 			assert.NoError(err)
 			assert.Equal(maybeMainnetAddr, maybeMainnetAddrBytes)
+
+			// Round trip encoding and decoding json
+			mb, err := addr.MarshalJSON()
+			assert.NoError(err)
+
+			var newMainnetAddr Address
+			err = newMainnetAddr.UnmarshalJSON(mb)
+			assert.NoError(err)
+			// TODO support decoding with network natively
+			newMainnetAddr.SetNetwork(Mainnet)
+			assert.Equal(addr, newMainnetAddr)
 		})
 	}
 }


### PR DESCRIPTION
This PR addresses https://github.com/filecoin-project/go-address/issues/6

**what** This is to add support to serialize an address based on network.
**why** Currently when a filecoin address get encoded in to a string, it by defaults set the address to be a testnet address. However, we need to be able to encode the address into either testnet or mainnet address based on the network we are on.