### PR TITLE
enforce that the trailing bits of an address string are standard

### DIFF
--- a/address.go
+++ b/address.go
@@ -323,6 +323,11 @@ func decode(a string) (Address, error) {
 		return Undef, err
 	}
 
+	reencodedRaw := AddressEncoding.WithPadding(-1).EncodeToString(payloadcksm)
+	if reencodedRaw != raw {
+		return Undef, ErrInvalidEncoding
+	}
+
 	if len(payloadcksm)-ChecksumHashLength < 0 {
 		return Undef, ErrInvalidChecksum
 	}

--- a/address_test.go
+++ b/address_test.go
@@ -470,7 +470,7 @@ func TestInvalidStringAddresses(t *testing.T) {
 		{"t2gfvuyh7v2sx3patm1k23wdzmhyhtmqctasbr24y", base32.CorruptInputError(16)}, // '1' is not in base32 alphabet
 		{"t2gfvuyh7v2sx3paTm1k23wdzmhyhtmqctasbr24y", base32.CorruptInputError(14)}, // 'T' is not in base32 alphabet
 		{"t2", ErrInvalidLength},
-		{"t1234", ErrInvalidChecksum},
+		{"t1234q", ErrInvalidChecksum},
 	}
 
 	for _, tc := range testCases {
@@ -659,4 +659,15 @@ func TestIDMax(t *testing.T) {
 	var targetAddr Address
 	err = targetAddr.UnmarshalCBOR(&buf)
 	assert.True(t, errors.Is(err, ErrInvalidPayload), "%#v", err)
+}
+
+func TestTrailingBits(t *testing.T) {
+	goodStr := "f1xpbyy4tkdx5si2bgo37dubc2xwv6fum5tk57mia"
+	badStr := "f1xpbyy4tkdx5si2bgo37dubc2xwv6fum5tk57mid"
+
+	_, err := NewFromString(goodStr)
+	assert.NoError(t, err, "should be able to decode the good string")
+
+	_, err = NewFromString(badStr)
+	assert.True(t, errors.Is(err, ErrInvalidEncoding), "%#v", err)
 }

--- a/constants.go
+++ b/constants.go
@@ -41,6 +41,8 @@ var (
 	ErrInvalidLength = errors.New("invalid address length")
 	// ErrInvalidChecksum is returned when encountering an invalid address checksum.
 	ErrInvalidChecksum = errors.New("invalid address checksum")
+	// ErrInvalidEncoding is returned when encountering a non-standard encoding of an address.
+	ErrInvalidEncoding = errors.New("invalid encoding")
 )
 
 // UndefAddressString is the string used to represent an empty address when encoded to a string.


### PR DESCRIPTION
Fixes #22 