### PR TITLE
feat: implement f4 addressing

### DIFF
--- a/address.go
+++ b/address.go
@@ -253,7 +253,7 @@ func newAddress(protocol Protocol, payload []byte) (Address, error) {
 	case Delegated:
 		namespace, n, err := varint.FromUvarint(payload)
 		if err != nil {
-			return Undef, xerrors.Errorf("could not decode delegated address namespace : %v: %w", err, ErrInvalidPayload)
+			return Undef, xerrors.Errorf("could not decode delegated address namespace: %v: %w", err, ErrInvalidPayload)
 		}
 		if namespace > math.MaxInt64 {
 			return Undef, xerrors.Errorf("namespace id must be less than 2^63: %w", ErrInvalidPayload)

--- a/address.go
+++ b/address.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"math"
 	"strconv"
+	"strings"
 
 	cbor "github.com/ipfs/go-ipld-cbor"
 	"github.com/minio/blake2b-simd"
@@ -69,6 +70,8 @@ const (
 	Actor
 	// BLS represents the address BLS protocol.
 	BLS
+	// Delegated represents the delegated (f4) address protocol.
+	Delegated
 
 	Unknown = Protocol(255)
 )
@@ -177,6 +180,19 @@ func NewBLSAddress(pubkey []byte) (Address, error) {
 	return newAddress(BLS, pubkey)
 }
 
+// NewDelegatedAddress returns an address using the Delegated protocol.
+func NewDelegatedAddress(namespace uint64, subaddr []byte) (Address, error) {
+	if namespace > math.MaxInt64 {
+		return Undef, xerrors.New("namespace must be less than 2^63")
+	}
+	if len(subaddr) > MaxSubaddressLen {
+		return Undef, ErrInvalidLength
+	}
+
+	payload := append(varint.ToUvarint(namespace), subaddr...)
+	return newAddress(Delegated, payload)
+}
+
 // NewFromString returns the address represented by the string `addr`.
 func NewFromString(addr string) (Address, error) {
 	return decode(addr)
@@ -209,8 +225,9 @@ func addressHash(ingest []byte) []byte {
 }
 
 // FIXME: This needs to be unified with the logic of `decode` (which would
-//  handle the initial verification of the checksum separately), both are doing
-//  the exact same length checks.
+//
+//	handle the initial verification of the checksum separately), both are doing
+//	the exact same length checks.
 func newAddress(protocol Protocol, payload []byte) (Address, error) {
 	switch protocol {
 	case ID:
@@ -231,6 +248,17 @@ func newAddress(protocol Protocol, payload []byte) (Address, error) {
 		}
 	case BLS:
 		if len(payload) != BlsPublicKeyBytes {
+			return Undef, ErrInvalidLength
+		}
+	case Delegated:
+		namespace, n, err := varint.FromUvarint(payload)
+		if err != nil {
+			return Undef, xerrors.Errorf("could not decode delegated address namespace : %v: %w", err, ErrInvalidPayload)
+		}
+		if namespace > math.MaxInt64 {
+			return Undef, xerrors.Errorf("namespace id must be less than 2^63: %w", ErrInvalidPayload)
+		}
+		if len(payload)-n > MaxSubaddressLen {
 			return Undef, ErrInvalidLength
 		}
 	default:
@@ -259,17 +287,33 @@ func encode(network Network, addr Address) (string, error) {
 		return UndefAddressString, ErrUnknownNetwork
 	}
 
+	protocol := addr.Protocol()
+	payload := addr.Payload()
 	var strAddr string
-	switch addr.Protocol() {
-	case SECP256K1, Actor, BLS:
-		cksm := Checksum(append([]byte{addr.Protocol()}, addr.Payload()...))
-		strAddr = ntwk + fmt.Sprintf("%d", addr.Protocol()) + AddressEncoding.WithPadding(-1).EncodeToString(append(addr.Payload(), cksm[:]...))
+	switch protocol {
+	case SECP256K1, Actor, BLS, Delegated:
+		// The checksum and prefix is the same for all protocols
+		cksm := Checksum(append([]byte{protocol}, payload...))
+		strAddr = ntwk + fmt.Sprintf("%d", protocol)
+
+		// if delegated, we need to write the namespace out separately.
+		if protocol == Delegated {
+			namespace, n, err := varint.FromUvarint(payload)
+			if err != nil {
+				return UndefAddressString, xerrors.Errorf("could not decode delegated address namespace: %w", err)
+			}
+			payload = payload[n:]
+			strAddr += fmt.Sprintf("%df", namespace)
+		}
+
+		// Then encode the payload (or the rest of it) and the checksum.
+		strAddr += AddressEncoding.WithPadding(-1).EncodeToString(append(payload, cksm[:]...))
 	case ID:
-		i, n, err := varint.FromUvarint(addr.Payload())
+		i, n, err := varint.FromUvarint(payload)
 		if err != nil {
 			return UndefAddressString, xerrors.Errorf("could not decode varint: %w", err)
 		}
-		if n != len(addr.Payload()) {
+		if n != len(payload) {
 			return UndefAddressString, xerrors.Errorf("payload contains additional bytes")
 		}
 		strAddr = fmt.Sprintf("%s%d%d", ntwk, addr.Protocol(), i)
@@ -277,6 +321,19 @@ func encode(network Network, addr Address) (string, error) {
 		return UndefAddressString, ErrUnknownProtocol
 	}
 	return strAddr, nil
+}
+
+func base32decode(s string) ([]byte, error) {
+	decoded, err := AddressEncoding.WithPadding(-1).DecodeString(s)
+	if err != nil {
+		return nil, err
+	}
+
+	reencoded := AddressEncoding.WithPadding(-1).EncodeToString(decoded)
+	if reencoded != s {
+		return nil, ErrInvalidEncoding
+	}
+	return decoded, nil
 }
 
 func decode(a string) (Address, error) {
@@ -304,6 +361,8 @@ func decode(a string) (Address, error) {
 		protocol = Actor
 	case '3':
 		protocol = BLS
+	case '4':
+		protocol = Delegated
 	default:
 		return Undef, ErrUnknownProtocol
 	}
@@ -320,36 +379,65 @@ func decode(a string) (Address, error) {
 		return newAddress(protocol, varint.ToUvarint(id))
 	}
 
-	payloadcksm, err := AddressEncoding.WithPadding(-1).DecodeString(raw)
-	if err != nil {
-		return Undef, err
-	}
+	var cksum, payload []byte
+	if protocol == Delegated {
+		parts := strings.SplitN(raw, "f", 2)
+		if len(parts) != 2 {
+			return Undef, ErrInvalidPayload
+		}
+		namespaceStr := parts[0]
+		subaddrStr := parts[1]
 
-	reencodedRaw := AddressEncoding.WithPadding(-1).EncodeToString(payloadcksm)
-	if reencodedRaw != raw {
-		return Undef, ErrInvalidEncoding
-	}
-
-	if len(payloadcksm) < ChecksumHashLength {
-		return Undef, ErrInvalidLength
-	}
-
-	payload := payloadcksm[:len(payloadcksm)-ChecksumHashLength]
-	cksm := payloadcksm[len(payloadcksm)-ChecksumHashLength:]
-
-	if protocol == SECP256K1 || protocol == Actor {
-		if len(payload) != PayloadHashLength {
+		if len(namespaceStr) > MaxInt64StringLength {
 			return Undef, ErrInvalidLength
+		}
+		namespace, err := strconv.ParseUint(namespaceStr, 10, 63)
+		if err != nil {
+			return Undef, ErrInvalidPayload
+		}
+
+		subaddrcksm, err := base32decode(subaddrStr)
+		if err != nil {
+			return Undef, err
+		}
+
+		if len(subaddrcksm) < ChecksumHashLength {
+			return Undef, ErrInvalidLength
+		}
+		subaddr := subaddrcksm[:len(subaddrcksm)-ChecksumHashLength]
+		cksum = subaddrcksm[len(subaddrcksm)-ChecksumHashLength:]
+		if len(subaddr) > MaxSubaddressLen {
+			return Undef, ErrInvalidLength
+		}
+
+		payload = append(varint.ToUvarint(namespace), subaddr...)
+	} else {
+		payloadcksm, err := base32decode(raw)
+		if err != nil {
+			return Undef, err
+		}
+
+		if len(payloadcksm) < ChecksumHashLength {
+			return Undef, ErrInvalidLength
+		}
+
+		payload = payloadcksm[:len(payloadcksm)-ChecksumHashLength]
+		cksum = payloadcksm[len(payloadcksm)-ChecksumHashLength:]
+
+		if protocol == SECP256K1 || protocol == Actor {
+			if len(payload) != PayloadHashLength {
+				return Undef, ErrInvalidLength
+			}
+		}
+
+		if protocol == BLS {
+			if len(payload) != BlsPublicKeyBytes {
+				return Undef, ErrInvalidLength
+			}
 		}
 	}
 
-	if protocol == BLS {
-		if len(payload) != BlsPublicKeyBytes {
-			return Undef, ErrInvalidLength
-		}
-	}
-
-	if !ValidateChecksum(append([]byte{protocol}, payload...), cksm) {
+	if !ValidateChecksum(append([]byte{protocol}, payload...), cksum) {
 		return Undef, ErrInvalidChecksum
 	}
 

--- a/address_test.go
+++ b/address_test.go
@@ -478,7 +478,7 @@ func TestInvalidByteAddresses(t *testing.T) {
 
 		// Delegate Protocol
 		// - subaddress exceeds the limit
-		{append([]byte{4, 0}, make([]byte, MaxSubaddressLen+1, MaxSubaddressLen+1)...), ErrInvalidLength},
+		{append([]byte{4, 0}, make([]byte, MaxSubaddressLen+1)...), ErrInvalidLength},
 		// - a hanging uvarint for a namespace
 		{[]byte{4, 0xff}, ErrInvalidPayload},
 	}
@@ -655,7 +655,7 @@ func TestDelegatedAddress(t *testing.T) {
 	}{
 		{32, []byte{0xff, 0xff, 0xff, 0xff, 0xff}, "f432f77777777x32lpna"},
 		{varint.MaxValueUvarint63, []byte{}, "f49223372036854775807fiic6zsy"},
-		{varint.MaxValueUvarint63, make([]byte, MaxSubaddressLen, MaxSubaddressLen), "f49223372036854775807faaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaahwgiuam"},
+		{varint.MaxValueUvarint63, make([]byte, MaxSubaddressLen), "f49223372036854775807faaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaahwgiuam"},
 	}
 
 	CurrentNetwork = Mainnet

--- a/address_test.go
+++ b/address_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/multiformats/go-varint"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/xerrors"
 
 	cbg "github.com/whyrusleeping/cbor-gen"
 )
@@ -89,28 +90,8 @@ func TestVectorsIDAddress(t *testing.T) {
 			// Round trip encoding and decoding from string
 			addr, err := NewIDAddress(tc.input)
 			assert.NoError(err)
-			assert.Equal(tc.expected, addr.String())
 
-			maybeAddr, err := NewFromString(tc.expected)
-			assert.NoError(err)
-			assert.Equal(ID, maybeAddr.Protocol())
-			id, _, err := varint.FromUvarint(maybeAddr.Payload())
-			assert.NoError(err)
-			assert.Equal(tc.input, id)
-
-			// Round trip to and from bytes
-			maybeAddrBytes, err := NewFromBytes(maybeAddr.Bytes())
-			assert.NoError(err)
-			assert.Equal(maybeAddr, maybeAddrBytes)
-
-			// Round trip encoding and decoding json
-			b, err := addr.MarshalJSON()
-			assert.NoError(err)
-
-			var newAddr Address
-			err = newAddr.UnmarshalJSON(b)
-			assert.NoError(err)
-			assert.Equal(addr, newAddr)
+			validateAddress(t, addr, varint.ToUvarint(tc.input), tc.expected)
 		})
 	}
 
@@ -188,51 +169,12 @@ func TestVectorSecp256k1Address(t *testing.T) {
 			CurrentNetwork = Testnet
 			addr, err := NewSecp256k1Address(tc.input)
 			assert.NoError(err)
-			assert.Equal(tc.expectedTestnetAddrStr, addr.String())
-
-			maybeTestnetAddr, err := NewFromString(tc.expectedTestnetAddrStr)
-			assert.NoError(err)
-			assert.Equal(SECP256K1, maybeTestnetAddr.Protocol())
-			assert.Equal(addressHash(tc.input), maybeTestnetAddr.Payload())
-
-			// Round trip to and from bytes
-			maybeTestnetAddrBytes, err := NewFromBytes(maybeTestnetAddr.Bytes())
-			assert.NoError(err)
-			assert.Equal(maybeTestnetAddr, maybeTestnetAddrBytes)
-
-			// Round trip encoding and decoding json
-			tb, err := addr.MarshalJSON()
-			assert.NoError(err)
-
-			var newTestnetAddr Address
-			err = newTestnetAddr.UnmarshalJSON(tb)
-			assert.NoError(err)
-			assert.Equal(addr, newTestnetAddr)
+			validateAddress(t, addr, addressHash(tc.input), tc.expectedTestnetAddrStr)
 
 			// Mainnet
 			// Round trip encoding and decoding from string
 			CurrentNetwork = Mainnet
-			assert.Equal(tc.expectedMainnetAddrStr, addr.String())
-
-			maybeMainnetAddr, err := NewFromString(tc.expectedMainnetAddrStr)
-			assert.NoError(err)
-			assert.Equal(SECP256K1, maybeMainnetAddr.Protocol())
-			assert.Equal(addressHash(tc.input), maybeMainnetAddr.Payload())
-
-			// Round trip to and from bytes
-			maybeMainnetAddrBytes, err := NewFromBytes(maybeMainnetAddr.Bytes())
-			assert.NoError(err)
-			assert.Equal(maybeMainnetAddr, maybeMainnetAddrBytes)
-
-			// Round trip encoding and decoding json
-			mb, err := addr.MarshalJSON()
-			assert.NoError(err)
-
-			var newMainnetAddr Address
-			err = newMainnetAddr.UnmarshalJSON(mb)
-			assert.NoError(err)
-			assert.Equal(addr, newMainnetAddr)
-
+			validateAddress(t, addr, addressHash(tc.input), tc.expectedMainnetAddrStr)
 		})
 	}
 }
@@ -253,7 +195,6 @@ func TestRandomActorAddress(t *testing.T) {
 	maybe, err := decode(str)
 	assert.NoError(err)
 	assert.Equal(addr, maybe)
-
 }
 
 func TestVectorActorAddress(t *testing.T) {
@@ -304,52 +245,43 @@ func TestVectorActorAddress(t *testing.T) {
 			CurrentNetwork = Testnet
 			addr, err := NewActorAddress(tc.input)
 			assert.NoError(err)
-			assert.Equal(tc.expectedTestnetAddrStr, addr.String())
 
-			maybeTestnetAddr, err := NewFromString(tc.expectedTestnetAddrStr)
-			assert.NoError(err)
-			assert.Equal(Actor, maybeTestnetAddr.Protocol())
-			assert.Equal(addressHash(tc.input), maybeTestnetAddr.Payload())
-
-			// Round trip to and from bytes
-			maybeTestnetAddrBytes, err := NewFromBytes(maybeTestnetAddr.Bytes())
-			assert.NoError(err)
-			assert.Equal(maybeTestnetAddr, maybeTestnetAddrBytes)
-
-			// Round trip encoding and decoding json
-			tb, err := addr.MarshalJSON()
-			assert.NoError(err)
-
-			var newTestnetAddr Address
-			err = newTestnetAddr.UnmarshalJSON(tb)
-			assert.NoError(err)
-			assert.Equal(addr, newTestnetAddr)
+			validateAddress(t, addr, addressHash(tc.input), tc.expectedTestnetAddrStr)
 
 			// Mainnet
 			// Round trip encoding and decoding from string
 			CurrentNetwork = Mainnet
-			assert.Equal(tc.expectedMainnetAddrStr, addr.String())
-
-			maybeMainnetAddr, err := NewFromString(tc.expectedMainnetAddrStr)
-			assert.NoError(err)
-			assert.Equal(Actor, maybeMainnetAddr.Protocol())
-			assert.Equal(addressHash(tc.input), maybeMainnetAddr.Payload())
-
-			// Round trip to and from bytes
-			maybeMainnetAddrBytes, err := NewFromBytes(maybeMainnetAddr.Bytes())
-			assert.NoError(err)
-			assert.Equal(maybeMainnetAddr, maybeMainnetAddrBytes)
-
-			// Round trip encoding and decoding json
-			mb, err := addr.MarshalJSON()
-			assert.NoError(err)
-
-			var newMainnetAddr Address
-			err = newMainnetAddr.UnmarshalJSON(mb)
-			assert.NoError(err)
-			assert.Equal(addr, newMainnetAddr)
+			validateAddress(t, addr, addressHash(tc.input), tc.expectedMainnetAddrStr)
 		})
 	}
+}
+
+func validateAddress(t *testing.T, addr Address, expectedPayload []byte, expectedString string) {
+	t.Helper()
+	assert := assert.New(t)
+
+	assert.Equal(expectedString, addr.String())
+
+	// Round trip from the string.
+	parsed, err := NewFromString(expectedString)
+	assert.NoError(err)
+	assert.Equal(addr.Protocol(), parsed.Protocol())
+	assert.Equal(expectedPayload, parsed.Payload())
+	assert.Equal(addr.Payload(), parsed.Payload())
+
+	// Round trip to and from bytes from the string.
+	fromBytes, err := NewFromBytes(parsed.Bytes())
+	assert.NoError(err)
+	assert.Equal(parsed, fromBytes)
+
+	// Round trip encoding and decoding json
+	mb, err := addr.MarshalJSON()
+	assert.NoError(err)
+
+	var parsedJson Address
+	err = parsedJson.UnmarshalJSON(mb)
+	assert.NoError(err)
+	assert.Equal(addr, parsedJson)
 }
 
 func TestVectorBLSAddress(t *testing.T) {
@@ -523,8 +455,8 @@ func TestInvalidStringAddresses(t *testing.T) {
 
 func TestInvalidByteAddresses(t *testing.T) {
 	testCases := []struct {
-		input    []byte
-		expetErr error
+		input     []byte
+		expectErr error
 	}{
 		// Unknown Protocol
 		{[]byte{5, 4, 4}, ErrUnknownProtocol},
@@ -535,6 +467,7 @@ func TestInvalidByteAddresses(t *testing.T) {
 		// SECP256K1 Protocol
 		{append([]byte{1}, make([]byte, PayloadHashLength-1)...), ErrInvalidLength},
 		{append([]byte{1}, make([]byte, PayloadHashLength+1)...), ErrInvalidLength},
+
 		// Actor Protocol
 		{append([]byte{2}, make([]byte, PayloadHashLength-1)...), ErrInvalidLength},
 		{append([]byte{2}, make([]byte, PayloadHashLength+1)...), ErrInvalidLength},
@@ -542,15 +475,21 @@ func TestInvalidByteAddresses(t *testing.T) {
 		// BLS Protocol
 		{append([]byte{3}, make([]byte, BlsPublicKeyBytes-1)...), ErrInvalidLength},
 		{append([]byte{3}, make([]byte, BlsPrivateKeyBytes+1)...), ErrInvalidLength},
+
+		// Delegate Protocol
+		// - subaddress exceeds the limit
+		{append([]byte{4, 0}, make([]byte, MaxSubaddressLen+1, MaxSubaddressLen+1)...), ErrInvalidLength},
+		// - a hanging uvarint for a namespace
+		{[]byte{4, 0xff}, ErrInvalidPayload},
 	}
 
 	for _, tc := range testCases {
 		tc := tc
-		t.Run(fmt.Sprintf("testing byte address: %s", tc.expetErr), func(t *testing.T) {
+		t.Run(fmt.Sprintf("testing byte address: %s", tc.expectErr), func(t *testing.T) {
 			assert := assert.New(t)
 
 			_, err := NewFromBytes(tc.input)
-			assert.Equal(tc.expetErr, err)
+			assert.True(xerrors.Is(err, tc.expectErr))
 		})
 	}
 
@@ -706,4 +645,27 @@ func TestTrailingBits(t *testing.T) {
 
 	_, err = NewFromString(badStr)
 	assert.True(t, errors.Is(err, ErrInvalidEncoding), "%#v", err)
+}
+
+func TestDelegatedAddress(t *testing.T) {
+	cases := []struct {
+		namespace  uint64
+		subaddress []byte
+		expected   string
+	}{
+		{32, []byte{0xff, 0xff, 0xff, 0xff, 0xff}, "f432f77777777x32lpna"},
+		{varint.MaxValueUvarint63, []byte{}, "f49223372036854775807fiic6zsy"},
+		{varint.MaxValueUvarint63, make([]byte, MaxSubaddressLen, MaxSubaddressLen), "f49223372036854775807faaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaahwgiuam"},
+	}
+
+	CurrentNetwork = Mainnet
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("delegated_%s", tc.expected), func(t *testing.T) {
+			addr, err := NewDelegatedAddress(tc.namespace, tc.subaddress)
+			assert.NoError(t, err)
+			payload := append(varint.ToUvarint(tc.namespace), tc.subaddress...)
+			validateAddress(t, addr, payload, tc.expected)
+		})
+	}
 }

--- a/address_test.go
+++ b/address_test.go
@@ -474,7 +474,7 @@ func TestInvalidStringAddresses(t *testing.T) {
 		expetErr      error
 	}{
 		{"Q2gfvuyh7v2sx3patm5k23wdzmhyhtmqctasbr23y", "", ErrUnknownNetwork},
-		{"t4gfvuyh7v2sx3patm5k23wdzmhyhtmqctasbr23y", "", ErrUnknownProtocol},
+		{"t5gfvuyh7v2sx3patm5k23wdzmhyhtmqctasbr23y", "", ErrUnknownProtocol},
 		{"t2gfvuyh7v2sx3patm5k23wdzmhyhtmqctasbr24y", "", ErrInvalidChecksum},
 		{"t0banananananannnnnnnnn", "", ErrInvalidLength},
 		{"t0banananananannnnnnn", "", ErrInvalidPayload},
@@ -483,7 +483,7 @@ func TestInvalidStringAddresses(t *testing.T) {
 		{"t2", "", ErrInvalidLength},
 		{"t1234q", "", ErrInvalidLength},
 		{"Q2gfvuyh7v2sx3patm5k23wdzmhyhtmqctasbr23y", "", ErrUnknownNetwork},
-		{"t4gfvuyh7v2sx3patm5k23wdzmhyhtmqctasbr23y", "", ErrUnknownProtocol},
+		{"t5gfvuyh7v2sx3patm5k23wdzmhyhtmqctasbr23y", "", ErrUnknownProtocol},
 		{"t2gfvuyh7v2sx3patm5k23wdzmhyhtmqctasbr24y", "", ErrInvalidChecksum},
 		{strings.Repeat("a", MaxAddressStringLength+1), "", ErrInvalidLength},
 		{"t", "", ErrInvalidLength},
@@ -527,7 +527,7 @@ func TestInvalidByteAddresses(t *testing.T) {
 		expetErr error
 	}{
 		// Unknown Protocol
-		{[]byte{4, 4, 4}, ErrUnknownProtocol},
+		{[]byte{5, 4, 4}, ErrUnknownProtocol},
 
 		// ID protocol
 		{[]byte{0}, ErrInvalidLength},

--- a/constants.go
+++ b/constants.go
@@ -57,15 +57,17 @@ const PayloadHashLength = 20
 // ChecksumHashLength defines the hash length used for calculating address checksums.
 const ChecksumHashLength = 4
 
-// MaxAddressStringLength is the max length of an address encoded as a string
-// it include the network prefx, protocol, and bls publickey
-const MaxAddressStringLength = 2 + 84
+// MaxAddressStringLength is the max length of an address encoded as a string (115).
+const MaxAddressStringLength = 2 + MaxInt64StringLength + 1 + 93
 
 // BlsPublicKeyBytes is the length of a BLS public key
 const BlsPublicKeyBytes = 48
 
 // BlsPrivateKeyBytes is the length of a BLS private key
 const BlsPrivateKeyBytes = 32
+
+// MaxSubaddressLen is the maximum length of a delegated address's sub-address.
+const MaxSubaddressLen = 54
 
 var payloadHashConfig = &blake2b.Config{Size: PayloadHashLength}
 var checksumHashConfig = &blake2b.Config{Size: ChecksumHashLength}


### PR DESCRIPTION
Implements FIP0048.

Note: users must independently make sure that their implementations only use f4 addressing if supported by their network. See https://github.com/filecoin-project/lotus/pull/9515.

fixes: https://github.com/filecoin-project/ref-fvm/issues/982

Closes https://github.com/filecoin-project/ref-fvm/issues/982