### PR TITLE
fix: failing test when run out of order

### DIFF
--- a/address_test.go
+++ b/address_test.go
@@ -88,6 +88,7 @@ func TestVectorsIDAddress(t *testing.T) {
 			assert := assert.New(t)
 
 			// Round trip encoding and decoding from string
+			CurrentNetwork = Testnet
 			addr, err := NewIDAddress(tc.input)
 			assert.NoError(err)
 


### PR DESCRIPTION
TestVectorsIDAddress fails when test run with -test.shuffle=on, i.e. they are dependent on ordering.

Example failing shuffle seed:

    -test.shuffle 1679689820085973000

After this fix, tests pass, verified via `go test -shuffle= 1679689820085973000 ` and `go test -shuffle=on -count=1000`

I noticed that PR #34 appears to enable test shuffling in CI, so this may unblock that.

(Longer term, it may be worth exploring getting the Network switching out of module level global state, but that's a bigger API design discussion potentially requiring a v2.)