### PR TITLE
chore: remove deprecated refs to unused filecoin-ffi

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "extern/filecoin-ffi"]
-	path = extern/filecoin-ffi
-	url = https://github.com/filecoin-project/filecoin-ffi.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,6 @@ import (
 	"testing"
 	"time"
 
-	ffi "github.com/filecoin-project/filecoin-ffi"
 	"github.com/multiformats/go-varint"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
filecoin-ffi as a dependency looks to have been removed in d94837d, but the submodule reference was left in .gitmodules, and there was a remaining extraneous reference in the contributors documentation.
